### PR TITLE
fix: userData 엔티티 - Plan 연관관계 설정에 따른 기존 코드 수정

### DIFF
--- a/src/main/java/eureca/capstone/project/orchestrator/common/dto/TelecomCompanyDto.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/common/dto/TelecomCompanyDto.java
@@ -16,4 +16,11 @@ public class TelecomCompanyDto {
                 .name(telecomCompany.getName())
                 .build();
     }
+
+    public static TelecomCompany toEntity(TelecomCompanyDto telecomCompanyDto) {
+        return TelecomCompany.builder()
+                .telecomCompanyId(telecomCompanyDto.getTelecomCompanyId())
+                .name(telecomCompanyDto.getName())
+                .build();
+    }
 }

--- a/src/main/java/eureca/capstone/project/orchestrator/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/common/exception/GlobalExceptionHandler.java
@@ -129,4 +129,10 @@ public class GlobalExceptionHandler {
         log.error(e.getMessage(), e);
         return BaseResponseDto.fail(ErrorCode.CHANGE_TYPE_NOT_FOUND);
     }
+
+    @ExceptionHandler(PlanNotFoundException.class)
+    public BaseResponseDto<ErrorResponseDto> handlePlanNotFoundException(PlanNotFoundException e) {
+        log.error(e.getMessage(), e);
+        return BaseResponseDto.fail(ErrorCode.PLAN_NOT_FOUND);
+    }
 }

--- a/src/main/java/eureca/capstone/project/orchestrator/common/exception/code/ErrorCode.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/common/exception/code/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
     // PLAN 관련 에러 코드 (20101 ~ 20150)
     RANDOM_PLAN_RETURN_FAIL(20101, "RANDOM_PLAN_RETURN_FAIL", "랜덤 요금제 조회 중 오류가 발생했습니다."),
     EMPTY_PLAN(20102, "EMPTY_PLAN", "요금제가 존재하지 않습니다."),
+    PLAN_NOT_FOUND(20103, "PLAN_NOT_FOUND", "요금제를 찾을 수 없습니다."),
 
     // transaction_feed 관련 에러코드 (30000 ~ 39999)
     TRANSACTION_FEED_CREATE_FAIL(30000, "TRANSACTION_FEED_CREATE_FAIL", "판매글 작성 도중 오류가 발생했습니다."),

--- a/src/main/java/eureca/capstone/project/orchestrator/common/exception/custom/PlanNotFoundException.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/common/exception/custom/PlanNotFoundException.java
@@ -1,0 +1,7 @@
+package eureca.capstone.project.orchestrator.common.exception.custom;
+
+public class PlanNotFoundException extends RuntimeException {
+    public PlanNotFoundException() {
+        super("요금제를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/eureca/capstone/project/orchestrator/user/dto/PlanDto.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/user/dto/PlanDto.java
@@ -1,0 +1,33 @@
+package eureca.capstone.project.orchestrator.user.dto;
+
+import eureca.capstone.project.orchestrator.common.dto.TelecomCompanyDto;
+import eureca.capstone.project.orchestrator.user.entity.Plan;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class PlanDto {
+    private Long planId;
+    private String planName;
+    private Long monthlyDataMb;
+    private TelecomCompanyDto telecomCompany;
+
+    public static PlanDto fromEntity(Plan plan) {
+        return PlanDto.builder()
+                .planId(plan.getPlanId())
+                .planName(plan.getPlanName())
+                .monthlyDataMb(plan.getMonthlyDataMb())
+                .telecomCompany(TelecomCompanyDto.fromEntity(plan.getTelecomCompany()))
+                .build();
+    }
+
+    public static Plan toEntity(PlanDto planDto) {
+        return Plan.builder()
+                .planId(planDto.getPlanId())
+                .planName(planDto.getPlanName())
+                .monthlyDataMb(planDto.getMonthlyDataMb())
+                .telecomCompany(TelecomCompanyDto.toEntity(planDto.getTelecomCompany()))
+                .build();
+    }
+}

--- a/src/main/java/eureca/capstone/project/orchestrator/user/dto/request/user_data/CreateUserDataRequestDto.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/user/dto/request/user_data/CreateUserDataRequestDto.java
@@ -1,5 +1,6 @@
 package eureca.capstone.project.orchestrator.user.dto.request.user_data;
 
+import eureca.capstone.project.orchestrator.user.dto.PlanDto;
 import eureca.capstone.project.orchestrator.user.entity.UserData;
 import lombok.Builder;
 import lombok.Data;
@@ -8,14 +9,14 @@ import lombok.Data;
 @Builder
 public class CreateUserDataRequestDto {
     private Long userId;
-    private Long planId;
+    private PlanDto plan;
     private Long monthlyDataMb;
     private Integer resetDataAt;
 
     public static UserData toEntity(CreateUserDataRequestDto requestDto) {
         return UserData.builder()
                 .userId(requestDto.getUserId())
-                .planId(requestDto.getPlanId())
+                .plan(PlanDto.toEntity(requestDto.getPlan()))
                 .totalDataMb(requestDto.getMonthlyDataMb())
                 .sellableDataMb(0L)
                 .buyerDataMb(0L)

--- a/src/main/java/eureca/capstone/project/orchestrator/user/repository/PlanRepository.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/user/repository/PlanRepository.java
@@ -2,14 +2,15 @@ package eureca.capstone.project.orchestrator.user.repository;
 
 import eureca.capstone.project.orchestrator.common.entity.TelecomCompany;
 import eureca.capstone.project.orchestrator.user.entity.Plan;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.Optional;
 
 public interface PlanRepository extends JpaRepository<Plan, Long> {
 
     @Query("SELECT p FROM Plan p WHERE p.telecomCompany = :telecomCompany ORDER BY FUNCTION('RAND')")
-    Optional<Plan> findRandomPlanByTelecomCompany(@Param("telecomCompany") TelecomCompany telecomCompany);
+    Page<Plan> findRandomPlanByTelecomCompany(@Param("telecomCompany") TelecomCompany telecomCompany, Pageable pageable);
 }

--- a/src/main/java/eureca/capstone/project/orchestrator/user/service/impl/PlanServiceImpl.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/user/service/impl/PlanServiceImpl.java
@@ -8,6 +8,8 @@ import eureca.capstone.project.orchestrator.user.repository.PlanRepository;
 import eureca.capstone.project.orchestrator.user.service.PlanService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -30,9 +32,13 @@ public class PlanServiceImpl implements PlanService {
     public RandomPlanResponseDto getRandomPlan(RandomPlanRequestDto randomPlanRequestDto) {
         log.info("[getRandomPlan] 랜덤 요금제 요청");
 
-        Plan randomPlan = planRepository.findRandomPlanByTelecomCompany(
-                randomPlanRequestDto.getTelecomCompany()
-        ).orElseThrow(EmptyPlanException::new);
+        Page<Plan> planPage = planRepository.findRandomPlanByTelecomCompany(
+                randomPlanRequestDto.getTelecomCompany(),
+                PageRequest.of(0, 1)
+        );
+
+        Plan randomPlan = planPage.get().findFirst()
+                .orElseThrow(EmptyPlanException::new);
 
         log.info("[getRandomPlan] 랜덤 요금제 선택: planId={}, monthlyDataMb={}", randomPlan.getPlanId(), randomPlan.getMonthlyDataMb());
 

--- a/src/main/java/eureca/capstone/project/orchestrator/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/user/service/impl/UserServiceImpl.java
@@ -8,12 +8,14 @@ import eureca.capstone.project.orchestrator.common.entity.TelecomCompany;
 import eureca.capstone.project.orchestrator.common.exception.code.ErrorCode;
 import eureca.capstone.project.orchestrator.common.exception.custom.EmailAlreadyExistsException;
 import eureca.capstone.project.orchestrator.common.exception.custom.InternalServerException;
+import eureca.capstone.project.orchestrator.common.exception.custom.PlanNotFoundException;
 import eureca.capstone.project.orchestrator.common.exception.custom.TelecomCompanyNotFoundException;
 import eureca.capstone.project.orchestrator.common.exception.custom.UserNotFoundException;
 import eureca.capstone.project.orchestrator.common.repository.TelecomCompanyRepository;
 import eureca.capstone.project.orchestrator.common.service.AIService;
 import eureca.capstone.project.orchestrator.common.service.EmailVerificationService;
 import eureca.capstone.project.orchestrator.common.util.StatusManager;
+import eureca.capstone.project.orchestrator.user.dto.PlanDto;
 import eureca.capstone.project.orchestrator.user.dto.request.plan.RandomPlanRequestDto;
 import eureca.capstone.project.orchestrator.user.dto.request.user.CreateUserRequestDto;
 import eureca.capstone.project.orchestrator.user.dto.request.user.UpdateNicknameRequestDto;
@@ -21,7 +23,9 @@ import eureca.capstone.project.orchestrator.user.dto.request.user.UpdatePassword
 import eureca.capstone.project.orchestrator.user.dto.request.user_data.CreateUserDataRequestDto;
 import eureca.capstone.project.orchestrator.user.dto.response.plan.RandomPlanResponseDto;
 import eureca.capstone.project.orchestrator.user.dto.response.user.*;
+import eureca.capstone.project.orchestrator.user.entity.Plan;
 import eureca.capstone.project.orchestrator.user.entity.User;
+import eureca.capstone.project.orchestrator.user.repository.PlanRepository;
 import eureca.capstone.project.orchestrator.user.repository.UserRepository;
 import eureca.capstone.project.orchestrator.user.service.PlanService;
 import eureca.capstone.project.orchestrator.user.service.UserDataService;
@@ -48,6 +52,7 @@ public class UserServiceImpl implements UserService {
     private final UserDataService userDataService;
     private final UserRepository userRepository;
     private final TelecomCompanyRepository telecomCompanyRepository;
+    private final PlanRepository planRepository;
     private final UserRoleRepository userRoleRepository;
     private final RoleRepository roleRepository;
     private final AIService aiService;
@@ -108,10 +113,13 @@ public class UserServiceImpl implements UserService {
                     .build();
             RandomPlanResponseDto randomPlan = planService.getRandomPlan(planReq);
 
+            Plan randomPlanEntity = planRepository.findById(randomPlan.getPlanId())
+                    .orElseThrow(PlanNotFoundException::new);
+
             // 사용자 데이터 레코드 생성
             CreateUserDataRequestDto userDataReq = CreateUserDataRequestDto.builder()
                     .userId(savedUser.getUserId())
-                    .planId(randomPlan.getPlanId())
+                    .plan(PlanDto.fromEntity(randomPlanEntity))
                     .monthlyDataMb(randomPlan.getMonthlyDataMb())
                     .resetDataAt(savedUser.getCreatedAt().getDayOfMonth())
                     .build();
@@ -254,10 +262,13 @@ public class UserServiceImpl implements UserService {
                 .build();
         RandomPlanResponseDto randomPlan = planService.getRandomPlan(planReq);
 
+        Plan randomPlanEntity = planRepository.findById(randomPlan.getPlanId())
+                .orElseThrow(PlanNotFoundException::new);
+
         // 사용자 데이터 레코드 생성
         CreateUserDataRequestDto createUserDataRequestDto = CreateUserDataRequestDto.builder()
                 .userId(savedUser.getUserId())
-                .planId(randomPlan.getPlanId())
+                .plan(PlanDto.fromEntity(randomPlanEntity))
                 .monthlyDataMb(randomPlan.getMonthlyDataMb())
                 .resetDataAt(savedUser.getCreatedAt().getDayOfMonth())
                 .build();

--- a/src/test/java/eureca/capstone/project/orchestrator/user/service/impl/PlanServiceImplTest.java
+++ b/src/test/java/eureca/capstone/project/orchestrator/user/service/impl/PlanServiceImplTest.java
@@ -6,6 +6,7 @@ import eureca.capstone.project.orchestrator.user.dto.request.plan.RandomPlanRequ
 import eureca.capstone.project.orchestrator.user.dto.response.plan.RandomPlanResponseDto;
 import eureca.capstone.project.orchestrator.user.entity.Plan;
 import eureca.capstone.project.orchestrator.user.repository.PlanRepository;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,6 +16,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -55,10 +59,11 @@ class PlanServiceImplTest {
         RandomPlanRequestDto requestDto = RandomPlanRequestDto.builder()
                 .telecomCompany(telecomCompany)
                 .build();
-        
-        when(planRepository.findRandomPlanByTelecomCompany(telecomCompany))
-                .thenReturn(Optional.of(plan));
 
+        Page<Plan> planPage = new PageImpl<>(List.of(plan));
+
+        when(planRepository.findRandomPlanByTelecomCompany(telecomCompany, PageRequest.of(0, 1)))
+                .thenReturn(planPage);
         // When
         RandomPlanResponseDto responseDto = planService.getRandomPlan(requestDto);
 
@@ -75,9 +80,9 @@ class PlanServiceImplTest {
         RandomPlanRequestDto requestDto = RandomPlanRequestDto.builder()
                 .telecomCompany(telecomCompany)
                 .build();
-        
-        when(planRepository.findRandomPlanByTelecomCompany(telecomCompany))
-                .thenReturn(Optional.empty());
+
+        when(planRepository.findRandomPlanByTelecomCompany(telecomCompany, PageRequest.of(0, 1)))
+                .thenReturn(Page.empty());
 
         // When & Then
         assertThrows(EmptyPlanException.class, () -> planService.getRandomPlan(requestDto));

--- a/src/test/java/eureca/capstone/project/orchestrator/user/service/impl/UserDataServiceImplTest.java
+++ b/src/test/java/eureca/capstone/project/orchestrator/user/service/impl/UserDataServiceImplTest.java
@@ -1,11 +1,14 @@
 package eureca.capstone.project.orchestrator.user.service.impl;
 
+import eureca.capstone.project.orchestrator.common.entity.TelecomCompany;
 import eureca.capstone.project.orchestrator.common.exception.custom.InternalServerException;
 import eureca.capstone.project.orchestrator.common.exception.custom.UserNotFoundException;
+import eureca.capstone.project.orchestrator.user.dto.PlanDto;
 import eureca.capstone.project.orchestrator.user.dto.request.user_data.CreateUserDataRequestDto;
 import eureca.capstone.project.orchestrator.user.dto.request.user_data.UpdateUserDataRequestDto;
 import eureca.capstone.project.orchestrator.user.dto.response.user_data.CreateSellableDataResponseDto;
 import eureca.capstone.project.orchestrator.user.dto.response.user_data.GetUserDataStatusResponseDto;
+import eureca.capstone.project.orchestrator.user.entity.Plan;
 import eureca.capstone.project.orchestrator.user.entity.User;
 import eureca.capstone.project.orchestrator.user.entity.UserData;
 import eureca.capstone.project.orchestrator.user.repository.UserDataRepository;
@@ -41,20 +44,35 @@ class UserDataServiceImplTest {
     @InjectMocks
     private UserDataServiceImpl userDataService;
 
+    private Plan plan;
     private UserData userData;
+    private TelecomCompany telecomCompany;
 
     @BeforeEach
     void setUp() {
         // 테스트에 사용할 객체 초기화
+        telecomCompany = TelecomCompany.builder()
+                .telecomCompanyId(1L)
+                .name("테스트 통신사")
+                .build();
+
+        plan = Plan.builder()
+                .planId(1L)
+                .planName("테스트 요금제")
+                .monthlyDataMb(10000L)
+                .telecomCompany(telecomCompany)
+                .build();
+
         userData = UserData.builder()
                 .userDataId(1L)
                 .userId(1L)
-                .planId(1L)
+                .plan(plan)
                 .totalDataMb(10000L)
                 .sellableDataMb(2000L)
                 .buyerDataMb(1000L)
                 .resetDataAt(1)
                 .build();
+
     }
 
     @Test
@@ -63,7 +81,7 @@ class UserDataServiceImplTest {
         // Given
         CreateUserDataRequestDto requestDto = CreateUserDataRequestDto.builder()
                 .userId(1L)
-                .planId(1L)
+                .plan(PlanDto.fromEntity( plan))
                 .monthlyDataMb(10000L)
                 .resetDataAt(1)
                 .build();


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> - #71

## 📝 작업 내용

> - plan, userData Dto 구조 변경 
> - 랜덤 요금제 조회 시, 페이지 설정을  통해 1개만 반환하도록 수정
> - 테스트 코드 수정 

## 🧾 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
