### PR TITLE
[VT2-76] 입찰 히스토리 목록 조회

### DIFF
--- a/src/main/java/eureca/capstone/project/orchestrator/common/config/RedisConfig.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/common/config/RedisConfig.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
@@ -46,10 +47,10 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisScript<String> bidScript() {
-        DefaultRedisScript<String> redisScript = new DefaultRedisScript<>();
+    public RedisScript<List> bidScript() {
+        DefaultRedisScript<List> redisScript = new DefaultRedisScript<>();
         redisScript.setLocation(new ClassPathResource("scripts/bid.lua"));
-        redisScript.setResultType(String.class);
+        redisScript.setResultType(List.class);
         return redisScript;
     }
 }

--- a/src/main/java/eureca/capstone/project/orchestrator/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/common/exception/GlobalExceptionHandler.java
@@ -141,4 +141,10 @@ public class GlobalExceptionHandler {
         log.error(e.getMessage(), e);
         return BaseResponseDto.fail(e.getErrorCode());
     }
+
+    @ExceptionHandler(PayLackException.class)
+    public BaseResponseDto<ErrorResponseDto> handlePayLackException(PayLackException e) {
+        log.error(e.getMessage(), e);
+        return BaseResponseDto.fail(ErrorCode.USER_PAY_LACK);
+    }
 }

--- a/src/main/java/eureca/capstone/project/orchestrator/common/exception/code/ErrorCode.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/common/exception/code/ErrorCode.java
@@ -58,6 +58,7 @@ public enum ErrorCode {
     CANNOT_BID_ON_OWN_HIGHEST(30013, "CANNOT_BID_ON_OWN_HIGHEST", "본인이 최고 입찰자일 때는 입찰할 수 없습니다."),
     FEED_NOT_AUCTION(30014, "FEED_NOT_AUCTION", "해당 판매글은 입찰 판매글이 아닙니다."),
     LUA_SCRIPT_ERROR(30015, "LUA_SCRIPT_ERROR", "루아 스크립트 실행 중 오류가 발생했습니다."),
+    BID_PROCESSING_FAILED(30016, "BID_PROCESSING_FAILED", "입찰 처리 중 오류가 발생했습니다."),
 
     // pay 관련 에러코드 (40000 ~ 49999)
 

--- a/src/main/java/eureca/capstone/project/orchestrator/common/exception/code/ErrorCode.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/common/exception/code/ErrorCode.java
@@ -74,6 +74,7 @@ public enum ErrorCode {
     CHANGE_TYPE_NOT_FOUND(40055, "CHANGE_TYPE_NOT_FOUND", "페이 변동 유형을 찾지 못했습니다."),
     PAYMENT_CANCELLED_BY_PAY_METHOD(40056, "PAYMENT_CANCELLED_BY_PAY_METHOD", "결제 수단 불일치로 결제가 취소되었습니다."),
     PAYMENT_CANCELLED_FAIL(40056, "PAYMENT_CANCELLED_FAIL", "결제 승인 취소에 실패하였습니다."),
+    USER_PAY_LACK(40057, "USER_PAY_LACK", "사용자 페이가 부족합니다."),
 
     // alarm 관련 에러코드 (50000 ~ 59999)
 

--- a/src/main/java/eureca/capstone/project/orchestrator/common/exception/custom/PayLackException.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/common/exception/custom/PayLackException.java
@@ -1,0 +1,7 @@
+package eureca.capstone.project.orchestrator.common.exception.custom;
+
+public class PayLackException extends RuntimeException {
+    public PayLackException() {
+        super("사용자 페이가 부족합니다.");
+    }
+}

--- a/src/main/java/eureca/capstone/project/orchestrator/pay/entity/UserPay.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/pay/entity/UserPay.java
@@ -1,6 +1,8 @@
 package eureca.capstone.project.orchestrator.pay.entity;
 
 import eureca.capstone.project.orchestrator.common.entity.BaseEntity;
+import eureca.capstone.project.orchestrator.common.exception.code.ErrorCode;
+import eureca.capstone.project.orchestrator.common.exception.custom.PayLackException;
 import eureca.capstone.project.orchestrator.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -37,5 +39,12 @@ public class UserPay extends BaseEntity {
 
     public void charge(Long amount) {
         this.pay += amount;
+    }
+
+    public void use(Long amount) {
+        if (this.pay < amount) {
+            throw new PayLackException();
+        }
+        this.pay -= amount;
     }
 }

--- a/src/main/java/eureca/capstone/project/orchestrator/pay/service/UserPayService.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/pay/service/UserPayService.java
@@ -5,4 +5,6 @@ import eureca.capstone.project.orchestrator.user.entity.User;
 
 public interface UserPayService {
     UserPay charge(User user, Long amount);
+    void usePay(User user, Long amount);
+    void refundPay(User user, Long amount);
 }

--- a/src/main/java/eureca/capstone/project/orchestrator/pay/service/impl/UserPayServiceImpl.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/pay/service/impl/UserPayServiceImpl.java
@@ -19,14 +19,33 @@ public class UserPayServiceImpl implements UserPayService {
     @Transactional
     public UserPay charge(User user, Long amount) {
         log.info("[charge] 사용자 ID: 페이 충전 시작. 충전 금액: {}", user.getUserId());
-
-        UserPay userPay = userPayRepository.findById(user.getUserId())
-                .orElseGet(() -> new UserPay(user));
-
+        UserPay userPay = findOrNewUserPay(user);
         userPay.charge(amount);
         userPayRepository.save(userPay);
         log.info("[charge] 사용자 ID: {} 페이 충전 완료. 현재 페이: {}", user.getUserId(), userPay.getPay());
-
         return userPay;
+    }
+
+    @Override
+    @Transactional
+    public void usePay(User user, Long amount) {
+        log.info("[usePay] 사용자 ID: {} 페이 사용 시작. 사용 금액: {}", user.getUserId(), amount);
+        UserPay userPay = findOrNewUserPay(user);
+        userPay.use(amount);
+        userPayRepository.save(userPay);
+    }
+
+    @Override
+    @Transactional
+    public void refundPay(User user, Long amount) {
+        log.info("[refundPay] 사용자 ID: {} 페이 환불 시작. 환불 금액: {}", user.getUserId(), amount);
+        charge(user, amount);
+        UserPay userPay = findOrNewUserPay(user);
+        log.info("[refundPay] 사용자 ID: {} 페이 환불 완료. 현재 페이: {}", user.getUserId(), userPay.getPay());
+    }
+
+    private UserPay findOrNewUserPay(User user) {
+        return userPayRepository.findById(user.getUserId())
+                .orElseGet(() -> new UserPay(user));
     }
 }

--- a/src/main/java/eureca/capstone/project/orchestrator/transaction_feed/controller/BidController.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/transaction_feed/controller/BidController.java
@@ -3,10 +3,13 @@ package eureca.capstone.project.orchestrator.transaction_feed.controller;
 import eureca.capstone.project.orchestrator.auth.dto.common.CustomUserDetailsDto;
 import eureca.capstone.project.orchestrator.common.dto.base.BaseResponseDto;
 import eureca.capstone.project.orchestrator.transaction_feed.dto.request.PlaceBidRequestDto;
+import eureca.capstone.project.orchestrator.transaction_feed.dto.response.GetBidHistoryResponseDto;
 import eureca.capstone.project.orchestrator.transaction_feed.service.BidService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,6 +20,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class BidController {
     private final BidService bidService;
+
+    @GetMapping("/{transactionFeedId}")
+    @Operation(summary = "입찰 내역 조회 API", description = "판매글의 입찰 내역을 조회합니다.")
+    public BaseResponseDto<GetBidHistoryResponseDto> getBidHistory(
+            @PathVariable Long transactionFeedId
+    ) {
+        GetBidHistoryResponseDto response = bidService.getBidHistory(transactionFeedId);
+        return BaseResponseDto.success(response);
+    }
 
     @PostMapping
     @Operation(summary = "입찰 API", description = "사용자가 판매글에 입찰합니다.")

--- a/src/main/java/eureca/capstone/project/orchestrator/transaction_feed/dto/BidDto.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/transaction_feed/dto/BidDto.java
@@ -1,0 +1,24 @@
+package eureca.capstone.project.orchestrator.transaction_feed.dto;
+
+import eureca.capstone.project.orchestrator.transaction_feed.entity.Bids;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class BidDto {
+    private Long bidId;
+    private String bidderNickname;
+    private Long bidAmount;
+    private LocalDateTime bidAt;
+
+    public static BidDto fromEntity(Bids bid) {
+        return BidDto.builder()
+                .bidId(bid.getBidsId())
+                .bidderNickname(bid.getUser().getNickname())
+                .bidAmount(bid.getBidAmount())
+                .bidAt(bid.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/eureca/capstone/project/orchestrator/transaction_feed/dto/response/GetBidHistoryResponseDto.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/transaction_feed/dto/response/GetBidHistoryResponseDto.java
@@ -1,0 +1,12 @@
+package eureca.capstone.project.orchestrator.transaction_feed.dto.response;
+
+import eureca.capstone.project.orchestrator.transaction_feed.dto.BidDto;
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class GetBidHistoryResponseDto {
+    private List<BidDto> bids;
+}

--- a/src/main/java/eureca/capstone/project/orchestrator/transaction_feed/entity/Bids.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/transaction_feed/entity/Bids.java
@@ -6,9 +6,11 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/eureca/capstone/project/orchestrator/transaction_feed/repository/BidsRepository.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/transaction_feed/repository/BidsRepository.java
@@ -1,7 +1,8 @@
 package eureca.capstone.project.orchestrator.transaction_feed.repository;
 
 import eureca.capstone.project.orchestrator.transaction_feed.entity.Bids;
+import eureca.capstone.project.orchestrator.transaction_feed.repository.custom.BidsRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface BidsRepository extends JpaRepository<Bids, Long> {
+public interface BidsRepository extends JpaRepository<Bids, Long>, BidsRepositoryCustom {
 }

--- a/src/main/java/eureca/capstone/project/orchestrator/transaction_feed/repository/custom/BidsRepositoryCustom.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/transaction_feed/repository/custom/BidsRepositoryCustom.java
@@ -1,0 +1,9 @@
+package eureca.capstone.project.orchestrator.transaction_feed.repository.custom;
+
+import eureca.capstone.project.orchestrator.transaction_feed.entity.Bids;
+import eureca.capstone.project.orchestrator.transaction_feed.entity.TransactionFeed;
+import java.util.List;
+
+public interface BidsRepositoryCustom {
+    List<Bids> findBidsWithUserByTransactionFeed(TransactionFeed transactionFeed);
+}

--- a/src/main/java/eureca/capstone/project/orchestrator/transaction_feed/repository/impl/BidsRepositoryImpl.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/transaction_feed/repository/impl/BidsRepositoryImpl.java
@@ -1,0 +1,28 @@
+package eureca.capstone.project.orchestrator.transaction_feed.repository.impl;
+
+import static eureca.capstone.project.orchestrator.transaction_feed.entity.QBids.bids;
+import static eureca.capstone.project.orchestrator.user.entity.QUser.user;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import eureca.capstone.project.orchestrator.transaction_feed.entity.Bids;
+import eureca.capstone.project.orchestrator.transaction_feed.entity.TransactionFeed;
+import eureca.capstone.project.orchestrator.transaction_feed.repository.custom.BidsRepositoryCustom;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class BidsRepositoryImpl implements BidsRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Bids> findBidsWithUserByTransactionFeed(TransactionFeed transactionFeed) {
+        return queryFactory
+                .selectFrom(bids)
+                .join(bids.user, user).fetchJoin()
+                .where(bids.transactionFeed.eq(transactionFeed))
+                .orderBy(bids.createdAt.desc())
+                .fetch();
+    }
+}

--- a/src/main/java/eureca/capstone/project/orchestrator/transaction_feed/service/BidService.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/transaction_feed/service/BidService.java
@@ -1,7 +1,9 @@
 package eureca.capstone.project.orchestrator.transaction_feed.service;
 
 import eureca.capstone.project.orchestrator.transaction_feed.dto.request.PlaceBidRequestDto;
+import eureca.capstone.project.orchestrator.transaction_feed.dto.response.GetBidHistoryResponseDto;
 
 public interface BidService {
     void placeBid(String email, PlaceBidRequestDto placeBidRequestDto);
+    GetBidHistoryResponseDto getBidHistory(Long transactionFeedId);
 }

--- a/src/main/java/eureca/capstone/project/orchestrator/transaction_feed/service/impl/BidServiceImpl.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/transaction_feed/service/impl/BidServiceImpl.java
@@ -8,6 +8,7 @@ import eureca.capstone.project.orchestrator.common.exception.custom.TransactionF
 import eureca.capstone.project.orchestrator.common.exception.custom.UserNotFoundException;
 import eureca.capstone.project.orchestrator.common.util.SalesTypeManager;
 import eureca.capstone.project.orchestrator.common.util.StatusManager;
+import eureca.capstone.project.orchestrator.pay.service.UserPayService;
 import eureca.capstone.project.orchestrator.transaction_feed.dto.request.PlaceBidRequestDto;
 import eureca.capstone.project.orchestrator.transaction_feed.entity.Bids;
 import eureca.capstone.project.orchestrator.transaction_feed.entity.SalesType;
@@ -35,8 +36,9 @@ public class BidServiceImpl implements BidService {
     private final UserRepository userRepository;
     private final TransactionFeedRepositoryCustom transactionFeedRepositoryCustom;
     private final BidsRepository bidsRepository;
+    private final UserPayService userPayService;
     private final StringRedisTemplate stringRedisTemplate;
-    private final RedisScript<String> bidScript;
+    private final RedisScript<List> bidScript;
     private final StatusManager statusManager;
     private final SalesTypeManager salesTypeManager;
 
@@ -55,7 +57,7 @@ public class BidServiceImpl implements BidService {
         String highestBidderKey = String.format("bids:%d:highest_bidder_id", feed.getTransactionFeedId());
 
         // 루아 스크립트 실행
-        String result = stringRedisTemplate.execute(
+        List result = stringRedisTemplate.execute(
                 bidScript,
                 List.of(highestPriceKey, highestBidderKey),
                 request.getBidAmount().toString(),
@@ -119,13 +121,39 @@ public class BidServiceImpl implements BidService {
         }
     }
 
-    private void handleBidResult(String result, TransactionFeed feed, User bidder, Long bidAmount) {
+    private void handleBidResult(List<Object> result, TransactionFeed feed, User newBidder, Long bidAmount) {
+        if (result == null || result.isEmpty()) {
+            log.error("[handleBidResult] 루아 스크립트 반환값이 비어있습니다.");
+            throw new InternalServerException(ErrorCode.LUA_SCRIPT_ERROR);
+        }
+
         log.info("[handleBidResult] 입찰 결과 처리 시작 - 결과: {}", result);
 
-        switch (Objects.requireNonNull(result)) {
+        String status = (String) result.get(0).toString();
+
+        switch (Objects.requireNonNull(status)) {
             case "SUCCESS" -> {
-                saveBidHistory(feed, bidder, bidAmount);
-                log.info("입찰 성공 - 사용자 ID: {}, 게시글 ID: {}, 입찰가: {}", bidder.getUserId(), feed.getTransactionFeedId(), bidAmount);
+                String prevBidderIdStr = (String) result.get(1);
+                String prevBidAmountStr = (String) result.get(2);
+                log.info("[handleBidResult] 입찰 성공");
+
+                if (!"0".equals(prevBidderIdStr)) {
+                    Long prevBidderId = Long.parseLong(prevBidderIdStr);
+                    Long prevBidAmount = Long.parseLong(prevBidAmountStr);
+                    log.info("[handleBidResult] 이전 입찰자 정보 - ID: {}, 금액: {}", prevBidderId, prevBidAmount);
+
+                    User prevBidder = userRepository.findById(prevBidderId)
+                            .orElseThrow(UserNotFoundException::new);
+
+                    userPayService.refundPay(prevBidder, prevBidAmount);
+                    log.info("[handleBidResult] 이전 입찰자 페이 환불 완료. 사용자 ID: {}, 환불 금액: {}", prevBidderId, prevBidAmount);
+                }
+
+                userPayService.usePay(newBidder, bidAmount);
+                log.info("[handleBidResult] 새로운 입찰자 페이 사용 완료. 사용자 ID: {}, 사용 금액: {}", newBidder.getUserId(), bidAmount);
+
+                saveBidHistory(feed, newBidder, bidAmount);
+                log.info("입찰 성공 - 사용자 ID: {}, 게시글 ID: {}, 입찰가: {}", newBidder.getUserId(), feed.getTransactionFeedId(), bidAmount);
                 // TODO: 입찰 성공 시 알림 기능 추가
             }
             case "BID_TOO_LOW" -> throw new BidException(ErrorCode.BID_AMOUNT_TOO_LOW);

--- a/src/main/java/eureca/capstone/project/orchestrator/transaction_feed/service/impl/BidServiceImpl.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/transaction_feed/service/impl/BidServiceImpl.java
@@ -9,7 +9,9 @@ import eureca.capstone.project.orchestrator.common.exception.custom.UserNotFound
 import eureca.capstone.project.orchestrator.common.util.SalesTypeManager;
 import eureca.capstone.project.orchestrator.common.util.StatusManager;
 import eureca.capstone.project.orchestrator.pay.service.UserPayService;
+import eureca.capstone.project.orchestrator.transaction_feed.dto.BidDto;
 import eureca.capstone.project.orchestrator.transaction_feed.dto.request.PlaceBidRequestDto;
+import eureca.capstone.project.orchestrator.transaction_feed.dto.response.GetBidHistoryResponseDto;
 import eureca.capstone.project.orchestrator.transaction_feed.entity.Bids;
 import eureca.capstone.project.orchestrator.transaction_feed.entity.SalesType;
 import eureca.capstone.project.orchestrator.transaction_feed.entity.TransactionFeed;
@@ -18,6 +20,7 @@ import eureca.capstone.project.orchestrator.transaction_feed.repository.custom.T
 import eureca.capstone.project.orchestrator.transaction_feed.service.BidService;
 import eureca.capstone.project.orchestrator.user.entity.User;
 import eureca.capstone.project.orchestrator.user.repository.UserRepository;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -66,6 +69,35 @@ public class BidServiceImpl implements BidService {
         log.info("[placeBid] 레디스 스크립트 실행 결과: {}", result);
 
         handleBidResult(result, feed, bidder, request.getBidAmount());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public GetBidHistoryResponseDto getBidHistory(Long transactionFeedId) {
+        log.info("[getBidHistory] 판매글 ID {} 입찰 내역 조회 시작", transactionFeedId);
+
+        TransactionFeed feed = findTransactionFeedById(transactionFeedId);
+        log.info("[getBidHistory] 판매글 조회 완료. ID: {}", transactionFeedId);
+
+        SalesType bidSalesType = salesTypeManager.getBidSaleType();
+        if (!feed.getSalesType().equals(bidSalesType)) {
+            log.error("[getBidHistory] 해당 판매글(ID:{})은 입찰 판매글이 아닙니다.", transactionFeedId);
+            throw new BidException(ErrorCode.FEED_NOT_AUCTION);
+        }
+        log.info("[getBidHistory] 입찰 판매글 검증 완료. ID: {}", transactionFeedId);
+
+        List<Bids> bids = bidsRepository.findBidsWithUserByTransactionFeed(feed);
+        log.info("[getBidHistory] 입찰 내역 {}건 조회 완료. ID: {}", bids.size(), transactionFeedId);
+
+        List<BidDto> bidDtos = bids.stream()
+                .map(BidDto::fromEntity)
+                .collect(Collectors.toList());
+
+        log.info("[getBidHistory] 판매글 ID {} 입찰 내역 DTO 변환 완료.", transactionFeedId);
+
+        return GetBidHistoryResponseDto.builder()
+                .bids(bidDtos)
+                .build();
     }
 
     private User findUserByEmail(String email) {
@@ -137,24 +169,39 @@ public class BidServiceImpl implements BidService {
                 String prevBidAmountStr = (String) result.get(2);
                 log.info("[handleBidResult] 입찰 성공");
 
-                if (!"0".equals(prevBidderIdStr)) {
-                    Long prevBidderId = Long.parseLong(prevBidderIdStr);
-                    Long prevBidAmount = Long.parseLong(prevBidAmountStr);
-                    log.info("[handleBidResult] 이전 입찰자 정보 - ID: {}, 금액: {}", prevBidderId, prevBidAmount);
+                try {
+                    if (!"0".equals(prevBidderIdStr)) {
+                        Long prevBidderId = Long.parseLong(prevBidderIdStr);
+                        Long prevBidAmount = Long.parseLong(prevBidAmountStr);
+                        log.info("[handleBidResult] 이전 입찰자 정보 - ID: {}, 금액: {}", prevBidderId, prevBidAmount);
 
-                    User prevBidder = userRepository.findById(prevBidderId)
-                            .orElseThrow(UserNotFoundException::new);
+                        User prevBidder = userRepository.findById(prevBidderId)
+                                .orElseThrow(UserNotFoundException::new);
 
-                    userPayService.refundPay(prevBidder, prevBidAmount);
-                    log.info("[handleBidResult] 이전 입찰자 페이 환불 완료. 사용자 ID: {}, 환불 금액: {}", prevBidderId, prevBidAmount);
+                        userPayService.refundPay(prevBidder, prevBidAmount);
+                        log.info("[handleBidResult] 이전 입찰자 페이 환불 완료. 사용자 ID: {}, 환불 금액: {}", prevBidderId, prevBidAmount);
+                    }
+
+                    userPayService.usePay(newBidder, bidAmount);
+                    log.info("[handleBidResult] 새로운 입찰자 페이 사용 완료. 사용자 ID: {}, 사용 금액: {}", newBidder.getUserId(), bidAmount);
+
+                    saveBidHistory(feed, newBidder, bidAmount);
+                    log.info("입찰 성공 - 사용자 ID: {}, 게시글 ID: {}, 입찰가: {}", newBidder.getUserId(), feed.getTransactionFeedId(), bidAmount);
+                    // TODO: 입찰 성공 시 알림 기능 추가
+
+                } catch (Exception e) {
+                    log.error("[handleBidResult] DB 작업 중 예외 발생. 보상 트랜잭션을 시작합니다.", e);
+
+                    String highestPriceKey = String.format("bids:%d:highest_price", feed.getTransactionFeedId());
+                    String highestBidderKey = String.format("bids:%d:highest_bidder_id", feed.getTransactionFeedId());
+
+                    stringRedisTemplate.opsForValue().set(highestPriceKey, prevBidAmountStr);
+                    stringRedisTemplate.opsForValue().set(highestBidderKey, prevBidderIdStr);
+
+                    log.info("[handleBidResult] 보상 트랜잭션 완료: Redis 상태를 이전으로 롤백했습니다.");
+
+                    throw new InternalServerException(ErrorCode.BID_PROCESSING_FAILED);
                 }
-
-                userPayService.usePay(newBidder, bidAmount);
-                log.info("[handleBidResult] 새로운 입찰자 페이 사용 완료. 사용자 ID: {}, 사용 금액: {}", newBidder.getUserId(), bidAmount);
-
-                saveBidHistory(feed, newBidder, bidAmount);
-                log.info("입찰 성공 - 사용자 ID: {}, 게시글 ID: {}, 입찰가: {}", newBidder.getUserId(), feed.getTransactionFeedId(), bidAmount);
-                // TODO: 입찰 성공 시 알림 기능 추가
             }
             case "BID_TOO_LOW" -> throw new BidException(ErrorCode.BID_AMOUNT_TOO_LOW);
             case "SAME_BIDDER" -> throw new BidException(ErrorCode.CANNOT_BID_ON_OWN_HIGHEST);

--- a/src/main/resources/scripts/bid.lua
+++ b/src/main/resources/scripts/bid.lua
@@ -3,21 +3,29 @@
 -- ARGV[1]: 새로 들어온 입찰가 (newBidAmount)
 -- ARGV[2]: 입찰자 ID (bidderId)
 
-local currentHighestBidder = redis.call('GET', KEYS[2])
-if currentHighestBidder and currentHighestBidder == ARGV[2] then
-    -- 현재 최고 입찰자가 새 입찰자와 동일한 경우, 최고가를 업데이트하지 않음
-    return 'SAME_BIDDER'
+-- 현재 저장된 최고가와 최고 입찰자 정보
+local prev_price = redis.call('get', KEYS[1])
+local prev_bidder_id = redis.call('get', KEYS[2])
+
+-- 새로운 입찰가와 입찰자 정보
+local new_price = tonumber(ARGV[1])
+local new_bidder_id = ARGV[2]
+
+-- 이전에 입찰한 사람이 현재 최고가로 다시 입찰하려는 경우
+if prev_bidder_id and prev_bidder_id == new_bidder_id then
+    return { 'SAME_BIDDER', '0', '0' }
 end
 
-local currentHighestPrice = redis.call('GET', KEYS[1])
-local newBidAmount = tonumber(ARGV[1])
+-- 첫 입찰이거나, 새로운 입찰가가 기존 최고가보다 높은 경우
+if not prev_price or new_price > tonumber(prev_price) then
+    -- 새로운 정보로 갱신
+    redis.call('set', KEYS[1], new_price)
+    redis.call('set', KEYS[2], new_bidder_id)
 
-if not currentHighestPrice or newBidAmount > tonumber(currentHighestPrice) then
-    -- 새 입찰가가 현재 최고가보다 높은 경우
-    redis.call('SET', KEYS[1], newBidAmount)
-    redis.call('SET', KEYS[2], ARGV[2])
-    return 'SUCCESS'
+    -- 성공 상태와 '이전' 입찰자 정보를 반환
+    -- 만약 첫 입찰이라 이전 정보가 없으면, 0 을 반환
+    return { 'SUCCESS', prev_bidder_id or '0', prev_price or '0' }
 else
-    -- 새 입찰가가 현재 최고가보다 낮거나 같은 경우
-    return 'BID_TOO_LOW'
+    -- 입찰가가 현재 최고가보다 낮거나 같은 경우
+    return { 'BID_TOO_LOW', '0', '0' }
 end

--- a/src/test/java/eureca/capstone/project/orchestrator/transaction_feed/service/impl/BidServiceImplTest.java
+++ b/src/test/java/eureca/capstone/project/orchestrator/transaction_feed/service/impl/BidServiceImplTest.java
@@ -179,4 +179,70 @@ class BidServiceImplTest {
             assertThrows(BidException.class, () -> bidService.placeBid(email, request));
         }
     }
+    @Nested
+    @DisplayName("입찰 내역 조회 기능")
+    class GetBidHistory {
+
+        @Test
+        @DisplayName("입찰 내역 조회 성공 시 입찰 내역 목록이 반환되어야 한다")
+        void getBidHistory_Success() {
+            // given
+            when(transactionFeedRepositoryCustom.findById(feedId)).thenReturn(Optional.of(feed));
+            when(salesTypeManager.getBidSaleType()).thenReturn(bidSalesType);
+            
+            List<Bids> bidsList = List.of(
+                Bids.builder()
+                    .bidsId(1L)
+                    .transactionFeed(feed)
+                    .user(bidder)
+                    .bidAmount(10000L)
+                    .build()
+            );
+            
+            when(bidsRepository.findBidsWithUserByTransactionFeed(feed)).thenReturn(bidsList);
+
+            // when
+            var result = bidService.getBidHistory(feedId);
+
+            // then
+            verify(transactionFeedRepositoryCustom).findById(feedId);
+            verify(salesTypeManager).getBidSaleType();
+            verify(bidsRepository).findBidsWithUserByTransactionFeed(feed);
+            org.assertj.core.api.Assertions.assertThat(result.getBids()).hasSize(1);
+            org.assertj.core.api.Assertions.assertThat(result.getBids().get(0).getBidAmount()).isEqualTo(10000L);
+            org.assertj.core.api.Assertions.assertThat(result.getBids().get(0).getBidderNickname()).isEqualTo(bidder.getNickname());
+        }
+
+        @Test
+        @DisplayName("입찰 판매글이 아닌 경우 예외가 발생해야 한다")
+        void getBidHistory_NotAuctionFeed() {
+            // given
+            SalesType directSalesType = SalesType.builder()
+                    .SalesTypeId(1L)
+                    .name("직접 판매")
+                    .build();
+            
+            TransactionFeed directFeed = TransactionFeed.builder()
+                    .transactionFeedId(feedId)
+                    .user(feed.getUser())
+                    .title("데이터 판매")
+                    .content("데이터 판매합니다")
+                    .telecomCompany(telecomCompany)
+                    .salesType(directSalesType)  // 직접 판매 타입
+                    .salesPrice(5000L)
+                    .salesDataAmount(1000L)
+                    .defaultImageNumber(1L)
+                    .expiresAt(LocalDateTime.now().plusDays(10))
+                    .status(onSaleStatus)
+                    .isDeleted(false)
+                    .build();
+            
+            when(transactionFeedRepositoryCustom.findById(feedId)).thenReturn(Optional.of(directFeed));
+            when(salesTypeManager.getBidSaleType()).thenReturn(bidSalesType);
+
+            // when & then
+            BidException exception = assertThrows(BidException.class, () -> bidService.getBidHistory(feedId));
+            org.assertj.core.api.Assertions.assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.FEED_NOT_AUCTION);
+        }
+    }
 }

--- a/src/test/java/eureca/capstone/project/orchestrator/transaction_feed/service/impl/BidServiceImplTest.java
+++ b/src/test/java/eureca/capstone/project/orchestrator/transaction_feed/service/impl/BidServiceImplTest.java
@@ -6,6 +6,7 @@ import eureca.capstone.project.orchestrator.common.exception.code.ErrorCode;
 import eureca.capstone.project.orchestrator.common.exception.custom.BidException;
 import eureca.capstone.project.orchestrator.common.util.SalesTypeManager;
 import eureca.capstone.project.orchestrator.common.util.StatusManager;
+import eureca.capstone.project.orchestrator.pay.service.UserPayService;
 import eureca.capstone.project.orchestrator.transaction_feed.dto.request.PlaceBidRequestDto;
 import eureca.capstone.project.orchestrator.transaction_feed.entity.Bids;
 import eureca.capstone.project.orchestrator.transaction_feed.entity.SalesType;
@@ -14,6 +15,7 @@ import eureca.capstone.project.orchestrator.transaction_feed.repository.BidsRepo
 import eureca.capstone.project.orchestrator.transaction_feed.repository.custom.TransactionFeedRepositoryCustom;
 import eureca.capstone.project.orchestrator.user.entity.User;
 import eureca.capstone.project.orchestrator.user.repository.UserRepository;
+import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -55,13 +57,16 @@ class BidServiceImplTest {
     private StringRedisTemplate stringRedisTemplate;
 
     @Mock
-    private RedisScript<String> bidScript;
+    private RedisScript<List> bidScript;
 
     @Mock
     private StatusManager statusManager;
 
     @Mock
     private SalesTypeManager salesTypeManager;
+
+    @Mock
+    private UserPayService userPayService;
 
     private User bidder;
     private TransactionFeed feed;
@@ -140,12 +145,15 @@ class BidServiceImplTest {
             when(transactionFeedRepositoryCustom.findById(feedId)).thenReturn(Optional.of(feed));
             when(statusManager.getStatus("FEED", "ON_SALE")).thenReturn(onSaleStatus);
             when(salesTypeManager.getBidSaleType()).thenReturn(bidSalesType);
+
+            List<String> mockResult = Arrays.asList("SUCCESS", "0", "0");
             when(stringRedisTemplate.execute(
                     any(RedisScript.class),
                     any(List.class),
                     anyString(),
                     anyString()
-            )).thenReturn("SUCCESS");
+            )).thenReturn(mockResult);
+
 
             // when
             bidService.placeBid(email, request);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> - https://lguplus20250120.atlassian.net/browse/VT2-76

## 📝 작업 내용

> - 입찰 성공 시 보유 페이 차감 및 복구 로직 추가
> - 입찰 관련 레디스 롤백 로직 추가
> - 입찰 내역 조회 기능 구현

## 🧾 스크린샷 (선택)
<img width="1674" height="848" alt="image" src="https://github.com/user-attachments/assets/b117ddae-8971-480b-90be-ac478522a42d" />

## 💬 리뷰 요구사항(선택)