### PR TITLE
[VT2-269] 소셜 로그인 검증 로직 변경

### DIFF
--- a/src/main/java/eureca/capstone/project/orchestrator/auth/constant/FilterConstant.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/auth/constant/FilterConstant.java
@@ -15,6 +15,8 @@ public class FilterConstant {
             "/login/oauth2/code/google",
             "/oauth2/authorization/google",
 
+            "/orchestrator/oauth/token",
+
             "/login/oauth2/code/**",
             "/oauth2/authorization/**",
 

--- a/src/main/java/eureca/capstone/project/orchestrator/auth/controller/OAuthController.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/auth/controller/OAuthController.java
@@ -1,0 +1,76 @@
+package eureca.capstone.project.orchestrator.auth.controller;
+
+import static eureca.capstone.project.orchestrator.common.constant.RedisConstant.REDIS_REFRESH_TOKEN;
+
+import eureca.capstone.project.orchestrator.auth.dto.response.LoginResponseDto;
+import eureca.capstone.project.orchestrator.auth.util.CookieUtil;
+import eureca.capstone.project.orchestrator.auth.util.JwtUtil;
+import eureca.capstone.project.orchestrator.common.dto.base.BaseResponseDto;
+import eureca.capstone.project.orchestrator.common.service.RedisService;
+import eureca.capstone.project.orchestrator.user.dto.UserInformationDto;
+import eureca.capstone.project.orchestrator.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServletResponse;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@Slf4j
+@RestController
+@RequestMapping("/orchestrator/oauth")
+@RequiredArgsConstructor
+public class OAuthController {
+    private final RedisService redisService;
+    private final JwtUtil jwtUtil;
+    private final CookieUtil cookieUtil;
+    private final UserRepository userRepository;
+
+    @PostMapping("/token")
+    public BaseResponseDto<LoginResponseDto> exchangeToken(@RequestBody Map<String, String> payload, HttpServletResponse httpServletResponse) {
+        String authCode = payload.get("authCode");
+        String redisKey = "oauth-temp-token:" + authCode;
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> tokenData = (Map<String, Object>) redisService.getValue(redisKey);
+
+        if (tokenData == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "유효하지 않거나 만료된 인증 코드입니다.");
+        }
+
+        redisService.deleteValue(redisKey); // 임시 코드 사용 후 즉시 삭제
+
+        String email = (String) tokenData.get("email");
+        boolean isNewUser = (boolean) tokenData.get("isNewUser");
+
+        // 사용자 정보 = 역할 권한 조회
+        UserInformationDto userInformationDto = userRepository.findUserInformation(email);
+        Long userId = userInformationDto.getUserId();
+        Set<String> roles = userInformationDto.getRoles();
+        Set<String> authorities = userInformationDto.getAuthorities();
+
+        // JWT 토큰 발급
+        String accessToken = jwtUtil.generateAccessToken(email, roles, authorities, userId);
+        String refreshToken = jwtUtil.generateRefreshToken(email, roles, authorities, userId);
+        log.info("[onAuthenticationSuccess] - accessToken: {}", accessToken);
+        log.info("[onAuthenticationSuccess] - refreshToken: {}", refreshToken);
+
+        // Refresh 토큰 Response 헤더에 할당 및 레디스에 저장 (14일 보관)
+        redisService.setValue(REDIS_REFRESH_TOKEN + userId, refreshToken, Duration.ofDays(14));
+        cookieUtil.createRefreshTokenCookie(refreshToken, httpServletResponse);
+
+        // 응답 객체 생성
+        LoginResponseDto loginResponse = LoginResponseDto.builder()
+                .accessToken(accessToken)
+                .isNewUser(isNewUser)
+                .build();
+
+        return BaseResponseDto.success(loginResponse);
+    }
+}

--- a/src/main/java/eureca/capstone/project/orchestrator/auth/dto/OAuthRegistrationResultDto.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/auth/dto/OAuthRegistrationResultDto.java
@@ -1,0 +1,9 @@
+package eureca.capstone.project.orchestrator.auth.dto;
+
+import lombok.Data;
+
+@Data
+public class OAuthRegistrationResultDto {
+    private final Long userId;
+    private final boolean isNewUser;
+}

--- a/src/main/java/eureca/capstone/project/orchestrator/auth/dto/response/LoginResponseDto.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/auth/dto/response/LoginResponseDto.java
@@ -7,4 +7,5 @@ import lombok.Data;
 @Builder
 public class LoginResponseDto {
     private String accessToken;
+    private boolean isNewUser;
 }

--- a/src/main/java/eureca/capstone/project/orchestrator/auth/service/impl/CustomOAuth2SuccessServiceImpl.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/auth/service/impl/CustomOAuth2SuccessServiceImpl.java
@@ -10,6 +10,7 @@ import eureca.capstone.project.orchestrator.user.dto.UserInformationDto;
 import eureca.capstone.project.orchestrator.user.repository.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
@@ -32,39 +33,24 @@ public class CustomOAuth2SuccessServiceImpl implements AuthenticationSuccessHand
     private final RedisService redisService;
     private final ObjectMapper objectMapper;
 
+    private static final String REDIRECT_URI = "https://ureca-final.com/auth-token";
+
     @Override
-    public void onAuthenticationSuccess(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, Authentication authentication) {
-        // 요청값 출력 및 키값 추출
+    public void onAuthenticationSuccess(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, Authentication authentication) throws IOException {
         OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
-        Long userId = oAuth2User.getAttribute("userId");
-        String email = oAuth2User.getAttribute("email");
-        log.info("[onAuthenticationSuccess] - userId: {}", userId);
-        log.info("[onAuthenticationSuccess] - email: {}", email);
+        String authCode = (String) oAuth2User.getAttributes().get("authCode");
+        log.info("[onAuthenticationSuccess] 인증 코드: {}", authCode);
 
-        // 사용자 정보 = 역할 권한 조회
-        UserInformationDto userInformationDto = userRepository.findUserInformation(email);
-        Set<String> roles = userInformationDto.getRoles();
-        Set<String> authorities = userInformationDto.getAuthorities();
+        if (authCode == null) {
+            log.warn("[onAuthenticationSuccess] 인증 코드가 누락되었습니다.");
+            httpServletResponse.sendRedirect(REDIRECT_URI + "?error=auth_code_missing");
+            return;
+        }
 
-        // JWT 토큰 발급
-        String accessToken = jwtUtil.generateAccessToken(email, roles, authorities, userId);
-        String refreshToken = jwtUtil.generateRefreshToken(email, roles, authorities, userId);
-        log.info("[onAuthenticationSuccess] - accessToken: {}", accessToken);
-        log.info("[onAuthenticationSuccess] - refreshToken: {}", refreshToken);
-
-        // Refresh 토큰 Response 헤더에 할당 및 레디스에 저장 (14일 보관)
-        cookieUtil.createRefreshTokenCookie(refreshToken, httpServletResponse);
-        redisService.setValue(REDIS_REFRESH_TOKEN + userId, refreshToken, Duration.ofDays(14));
-
-        // 응답 객체 생성
-        BaseResponseDto<LoginResponseDto> success = BaseResponseDto.success(
-                LoginResponseDto.builder()
-                        .accessToken(accessToken)
-                        .build()
-        );
-
-        // 객체 json 으로 변환 후 반환
-        writeJsonResponse(httpServletResponse, success);
+        // authCode와 함께 프론트엔드로 리다이렉트
+        String redirectUrl = REDIRECT_URI + "?authCode=" + authCode;
+        log.info("[onAuthenticationSuccess] 리다이렉트 URL: {}", redirectUrl);
+        httpServletResponse.sendRedirect(redirectUrl);
     }
 
     public void writeJsonResponse(HttpServletResponse httpServletResponse, Object dto) {

--- a/src/main/java/eureca/capstone/project/orchestrator/auth/service/impl/CustomOAuth2UserServiceImpl.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/auth/service/impl/CustomOAuth2UserServiceImpl.java
@@ -1,6 +1,10 @@
 package eureca.capstone.project.orchestrator.auth.service.impl;
 
+import eureca.capstone.project.orchestrator.auth.dto.OAuthRegistrationResultDto;
+import eureca.capstone.project.orchestrator.common.service.RedisService;
 import eureca.capstone.project.orchestrator.user.service.UserService;
+import java.time.Duration;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -21,6 +25,7 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class CustomOAuth2UserServiceImpl implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
     private final UserService userService;
+    private final RedisService redisService;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -50,13 +55,20 @@ public class CustomOAuth2UserServiceImpl implements OAuth2UserService<OAuth2User
 
         // TODO 활성화된 사용자인지 확인
 
+        // 사용자가 존재하는지 확인하고 등록 결과(userId, isNewUser)를 가져옴
+        OAuthRegistrationResultDto registrationResult = userService.OAuthUserRegisterIfNotExists(email, provider);
+        log.info("[loadUser] userId -> {}, isNewUser -> {}", registrationResult.getUserId(), registrationResult.isNewUser());
 
-        // 시스템에 등록되지 않은 OAuth 사용자 확인 및 등록 + 핸들러에서 사용할 userId, email 담기
-        Long userId = userService.OAuthUserRegisterIfNotExists(email, provider);
-        log.info("[loadUser] userId -> {}", userId);
+        // 임시 인증 코드를 생성하여 redis 에 저장
+        String authCode = UUID.randomUUID().toString();
+        Map<String, Object> redisPayload = new HashMap<>();
+        redisPayload.put("email", email);
+        redisPayload.put("isNewUser", registrationResult.isNewUser());
+        redisService.setValue("oauth-temp-token:" + authCode, redisPayload, Duration.ofMinutes(5)); // 5분 만료
+
+        // 성공 핸들러에 authCode를 전달하기 위해 속성에 추가
         Map<String, Object> deepCopyAttributes = new HashMap<>(attributes);
-        deepCopyAttributes.put("userId", userId);
-        deepCopyAttributes.put("email", email);
+        deepCopyAttributes.put("authCode", authCode);
 
         // return
         return new DefaultOAuth2User(

--- a/src/main/java/eureca/capstone/project/orchestrator/user/service/UserService.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/user/service/UserService.java
@@ -1,5 +1,6 @@
 package eureca.capstone.project.orchestrator.user.service;
 
+import eureca.capstone.project.orchestrator.auth.dto.OAuthRegistrationResultDto;
 import eureca.capstone.project.orchestrator.user.dto.request.user.CreateUserRequestDto;
 import eureca.capstone.project.orchestrator.user.dto.request.user.UpdateNicknameRequestDto;
 import eureca.capstone.project.orchestrator.user.dto.request.user.UpdatePasswordRequestDto;
@@ -15,5 +16,5 @@ public interface UserService {
     UpdateNicknameResponseDto updateUserNickname(String email, UpdateNicknameRequestDto updateUserNicknameRequestDto);
     UpdatePasswordResponseDto updateUserPassword(String email, UpdatePasswordRequestDto updatePasswordRequestDto);
     GetUserCountResponseDto getUserCount();
-    Long OAuthUserRegisterIfNotExists(String email, String provider);
+    OAuthRegistrationResultDto OAuthUserRegisterIfNotExists(String email, String provider);
 }

--- a/src/main/java/eureca/capstone/project/orchestrator/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/user/service/impl/UserServiceImpl.java
@@ -1,5 +1,6 @@
 package eureca.capstone.project.orchestrator.user.service.impl;
 
+import eureca.capstone.project.orchestrator.auth.dto.OAuthRegistrationResultDto;
 import eureca.capstone.project.orchestrator.auth.entity.UserRole;
 import eureca.capstone.project.orchestrator.auth.repository.RoleRepository;
 import eureca.capstone.project.orchestrator.auth.repository.UserRoleRepository;
@@ -228,11 +229,11 @@ public class UserServiceImpl implements UserService {
 
     @Transactional
     @Override
-    public Long OAuthUserRegisterIfNotExists(String email, String provider) {
+    public OAuthRegistrationResultDto OAuthUserRegisterIfNotExists(String email, String provider) {
         Optional<User> optionalUser = userRepository.findByEmail(email);
-        // 이미 존재하는 경우 → 아무 작업 없이 기존 유저 ID 반환
+        // 이미 사용자가 존재하면 ID를 반환하고, 신규 유저가 아님을 알림
         if (optionalUser.isPresent()) {
-            return optionalUser.get().getUserId();
+            return new OAuthRegistrationResultDto(optionalUser.get().getUserId(), false);
         }
 
         // 시스템에 존재하지 않은 경우, 회원 가입 처리 및 권한 부여
@@ -275,7 +276,8 @@ public class UserServiceImpl implements UserService {
 
         userDataService.createUserData(createUserDataRequestDto);
 
-        return savedUser.getUserId();
+        // 신규 사용자의 ID를 반환하고, 신규 유저임을 알림
+        return new OAuthRegistrationResultDto(savedUser.getUserId(), true);
     }
 
     private User findUserByEmail(String email) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> - https://lguplus20250120.atlassian.net/browse/VT2-269

## 📝 작업 내용

> - 소셜 로그인 시 JWT 토큰 응답에서 리다이렉트 및 임시 토큰 발급 방식으로 변경
> - 임시 토큰 검증 후 JWT 토큰 발급

## 🧾 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)