### PR TITLE
fix: 응답 dto에서 finalUserPay 필드 위치 변경

### DIFF
--- a/src/main/java/eureca/capstone/project/orchestrator/pay/dto/response/PayHistoryDetailResponseDto.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/pay/dto/response/PayHistoryDetailResponseDto.java
@@ -15,7 +15,6 @@ import lombok.Getter;
 public class PayHistoryDetailResponseDto {
     private Long payHistoryId;
     private String changeType;
-    private Long finalUserPay;
     private LocalDateTime createdAt;
 
     private ChargeDetailDto chargeDetail;
@@ -33,8 +32,9 @@ public class PayHistoryDetailResponseDto {
         private Long chargedPay;
         private LocalDateTime chargedAt;
         private String payTypeName;
+        private Long finalUserPay;
 
-        public static ChargeDetailDto fromEntity(ChargeHistory chargeHistory) {
+        public static ChargeDetailDto fromEntity(ChargeHistory chargeHistory, Long finalUserPay) {
             return ChargeDetailDto.builder()
                     .orderId(chargeHistory.getOrderId())
                     .paymentAmount(chargeHistory.getAmount())
@@ -43,6 +43,7 @@ public class PayHistoryDetailResponseDto {
                     .chargedPay(chargeHistory.getChargePay())
                     .chargedAt(chargeHistory.getCompletedAt())
                     .payTypeName(chargeHistory.getPayType() != null ? chargeHistory.getPayType().getName() : "정보없음")
+                    .finalUserPay(finalUserPay)
                     .build();
         }
     }
@@ -58,8 +59,9 @@ public class PayHistoryDetailResponseDto {
         private LocalDateTime exchangedAt;
         private String bankName;
         private String exchangeAccount;
+        private Long finalUserPay;
 
-        public static ExchangeDetailDto fromEntity(ExchangeHistory exchangeHistory, Long changedPay) {
+        public static ExchangeDetailDto fromEntity(ExchangeHistory exchangeHistory, Long changedPay, Long finalUserPay) {
             return ExchangeDetailDto.builder()
                     .exchangeHistoryId(exchangeHistory.getExchangeHistoryId())
                     .exchangeAmount(exchangeHistory.getAmount())
@@ -69,6 +71,7 @@ public class PayHistoryDetailResponseDto {
                     .exchangedAt(exchangeHistory.getCreatedAt())
                     .bankName(exchangeHistory.getBank() != null ? exchangeHistory.getBank().getBankName() : "정보없음")
                     .exchangeAccount(exchangeHistory.getExchangeAccount())
+                    .finalUserPay(finalUserPay)
                     .build();
         }
     }
@@ -82,8 +85,9 @@ public class PayHistoryDetailResponseDto {
         private Long transactionPay;
         private LocalDateTime transactedAt;
         private String telecom;
+        private Long finalUserPay;
 
-        public static TransactionDetailDto fromEntity(DataTransactionHistory txHistory, Long changedPay) {
+        public static TransactionDetailDto fromEntity(DataTransactionHistory txHistory, Long changedPay, Long finalUserPay) {
             return TransactionDetailDto.builder()
                     .transactionHistoryId(txHistory.getTransactionHistoryId())
                     .transactionType(txHistory.getTransactionFeed().getSalesType().getName())
@@ -91,6 +95,7 @@ public class PayHistoryDetailResponseDto {
                     .transactionPay(changedPay)
                     .transactedAt(txHistory.getCreatedAt())
                     .telecom(txHistory.getTransactionFeed().getTelecomCompany().getName())
+                    .finalUserPay(finalUserPay)
                     .build();
         }
     }

--- a/src/main/java/eureca/capstone/project/orchestrator/pay/service/impl/PayHistoryServiceImpl.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/pay/service/impl/PayHistoryServiceImpl.java
@@ -76,7 +76,6 @@ public class PayHistoryServiceImpl implements PayHistoryService {
         var responseBuilder = PayHistoryDetailResponseDto.builder()
                 .payHistoryId(payHistory.getPayHistoryId())
                 .changeType(payHistory.getChangeType().getType())
-                .finalUserPay(payHistory.getFinalPay())
                 .createdAt(payHistory.getCreatedAt());
 
         String type = payHistory.getChangeType().getType();
@@ -85,14 +84,14 @@ public class PayHistoryServiceImpl implements PayHistoryService {
             case "충전":
                 ChargeHistory chargeHistory = payHistoryRepository.findChargeHistoryByPayHistoryId(payHistoryId)
                         .orElseThrow(() -> new InternalServerException(ErrorCode.CHARGE_HISTORY_NOT_FOUND));
-                responseBuilder.chargeDetail(PayHistoryDetailResponseDto.ChargeDetailDto.fromEntity(chargeHistory));
+                responseBuilder.chargeDetail(PayHistoryDetailResponseDto.ChargeDetailDto.fromEntity(chargeHistory, payHistory.getFinalPay()));
                 log.info("[getPayHistoryDetail] ChargeHistory ID: {}", chargeHistory.getChargeHistoryId());
                 break;
 
             case "환전":
                 ExchangeHistory exchangeHistory = payHistoryRepository.findExchangeHistoryByPayHistoryId(payHistoryId)
                         .orElseThrow(() -> new InternalServerException(ErrorCode.EXCHANGE_HISTORY_NOT_FOUND));
-                responseBuilder.exchangeDetail(PayHistoryDetailResponseDto.ExchangeDetailDto.fromEntity(exchangeHistory, payHistory.getChangedPay()));
+                responseBuilder.exchangeDetail(PayHistoryDetailResponseDto.ExchangeDetailDto.fromEntity(exchangeHistory, payHistory.getChangedPay(), payHistory.getFinalPay()));
                 log.info("[getPayHistoryDetail] ExchangeHistory ID: {}", exchangeHistory.getExchangeHistoryId());
                 break;
 
@@ -100,7 +99,7 @@ public class PayHistoryServiceImpl implements PayHistoryService {
             case "판매":
                 DataTransactionHistory txHistory = payHistoryRepository.findTransactionHistoryByPayHistoryId(payHistoryId)
                         .orElseThrow(() -> new InternalServerException(ErrorCode.TRANSACTION_HISTORY_NOT_FOUND));
-                responseBuilder.transactionDetail(PayHistoryDetailResponseDto.TransactionDetailDto.fromEntity(txHistory, payHistory.getChangedPay()));
+                responseBuilder.transactionDetail(PayHistoryDetailResponseDto.TransactionDetailDto.fromEntity(txHistory, payHistory.getChangedPay(), payHistory.getFinalPay()));
                 log.info("[getPayHistoryDetail] DataTransactionHistory ID: {}", txHistory.getTransactionHistoryId());
                 break;
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

> 페이내역 상세 응답 dto에서 finalUserPay 필드의 위치를 ChargeDetailDto, ExchangeDetailDto, TransactionDetailDto 내부로 이동

## 🧾 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
