### PR TITLE
fix: 판매글 상세조회 리턴 결과에 sellerId 추가

### DIFF
--- a/src/main/java/eureca/capstone/project/orchestrator/transaction_feed/dto/response/GetFeedDetailResponseDto.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/transaction_feed/dto/response/GetFeedDetailResponseDto.java
@@ -13,6 +13,7 @@ import lombok.Data;
 @Builder
 public class GetFeedDetailResponseDto {
     private final Long transactionFeedId;
+    private final Long sellerId;
     private final String title;
     private final String content;
     private final Long salesDataAmount;

--- a/src/main/java/eureca/capstone/project/orchestrator/transaction_feed/service/impl/TransactionFeedServiceImpl.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/transaction_feed/service/impl/TransactionFeedServiceImpl.java
@@ -186,6 +186,7 @@ public class TransactionFeedServiceImpl implements TransactionFeedService {
         TransactionFeed feed = transactionFeedRepository.findFeedDetailById(transactionFeedId)
                 .orElseThrow(TransactionFeedNotFoundException::new);
 
+        Long sellerId = feed.getUser().getUserId();
         boolean isLiked = false;
         if (userDetailsDto != null) {
             User user = findUserByEmail(userDetailsDto.getEmail());
@@ -240,6 +241,7 @@ public class TransactionFeedServiceImpl implements TransactionFeedService {
 
         return GetFeedDetailResponseDto.builder()
                 .transactionFeedId(feed.getTransactionFeedId())
+                .sellerId(sellerId)
                 .title(feed.getTitle())
                 .content(feed.getContent())
                 .salesDataAmount(feed.getSalesDataAmount())


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> - #169 

## 📝 작업 내용

> - 판매글 상세조회 리턴 결과에 sellerId 추가

## 🧾 스크린샷 (선택)
<img width="1689" height="847" alt="image" src="https://github.com/user-attachments/assets/36b5db0a-9724-4b5a-884a-88858b052f09" />

## 💬 리뷰 요구사항(선택)