### PR TITLE
[VT2-452] feat: 데이터 충전권 정렬 시, 상태 기준 정렬

### DIFF
--- a/src/main/java/eureca/capstone/project/orchestrator/transaction_feed/repository/impl/UserDataCouponRepositoryImpl.java
+++ b/src/main/java/eureca/capstone/project/orchestrator/transaction_feed/repository/impl/UserDataCouponRepositoryImpl.java
@@ -5,11 +5,14 @@ import static eureca.capstone.project.orchestrator.common.entity.QTelecomCompany
 import static eureca.capstone.project.orchestrator.transaction_feed.entity.QDataCoupon.dataCoupon;
 import static eureca.capstone.project.orchestrator.transaction_feed.entity.QUserDataCoupon.userDataCoupon;
 
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import eureca.capstone.project.orchestrator.transaction_feed.entity.UserDataCoupon;
 import eureca.capstone.project.orchestrator.transaction_feed.repository.custom.UserDataCouponRepositoryCustom;
 import eureca.capstone.project.orchestrator.user.entity.User;
 import eureca.capstone.project.orchestrator.user.entity.UserData;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -25,12 +28,22 @@ public class UserDataCouponRepositoryImpl implements UserDataCouponRepositoryCus
 
     @Override
     public Page<UserDataCoupon> findDetailsByUser(User user, Pageable pageable) {
+        // 1. 최우선 정렬: 'ISSUED' 상태를 가장 먼저
+        OrderSpecifier<Integer> statusPriorityOrder = new CaseBuilder()
+                .when(status.code.eq("ISSUED")).then(1)
+                .otherwise(2) // ISSUED가 아닌 모든 상태는 2순위
+                .asc();
+
+        // 2. 보조 정렬: 만료일이 임박한 순서 (오름차순)
+        OrderSpecifier<LocalDateTime> expiryOrder = userDataCoupon.expiresAt.asc();
+
         List<UserDataCoupon> content = queryFactory
                 .selectFrom(userDataCoupon)
                 .join(userDataCoupon.dataCoupon, dataCoupon).fetchJoin()
                 .join(userDataCoupon.status, status).fetchJoin()
                 .leftJoin(dataCoupon.telecomCompany, telecomCompany).fetchJoin()
                 .where(userDataCoupon.user.eq(user))
+                .orderBy(statusPriorityOrder, expiryOrder)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> - https://lguplus20250120.atlassian.net/browse/VT2-452

## 📝 작업 내용

> - 데이터 충전권 정렬 기준 변경

## 🧾 스크린샷 (선택)
<img width="1665" height="846" alt="image" src="https://github.com/user-attachments/assets/5ede3143-63b6-424b-b6f2-5bf59f4613af" />


## 💬 리뷰 요구사항(선택)